### PR TITLE
Fix macOS compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo apt-get install build-essential pkg-config git libusb-1.0-0-dev libqt4-dev
 ### Checkout source code and compile 
 ```nohighlight
 git clone https://github.com/radiomanV/TL866
-cd TL866/QT
+cd TL866/TL866_Updater/QT
 qmake
 make
 sudo cp TL866_Updater /usr/local/bin
@@ -59,5 +59,16 @@ all users.
 #### macOS
 
 Follow instructions for Linux. You'll need libusb and libqt4 through
-a package installer. Macports has been used successfully. Udev doesn't
+a package installer. Macports and Homebrew have been used successfully. Udev doesn't
 exist for macOS so native IOKit is used instead.
+
+Homebrew instructions:
+
+```nohighlight
+brew install qt libusb pkg-config
+git clone https://github.com/radiomanV/TL866
+cd TL866/TL866_Updater/QT
+qmake
+make
+cp -R TL866_Updater.app /Applications
+```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ all users.
 
 #### macOS
 
-Follow instructions for Linux. You'll need libusb and libqt4 through
+Follow instructions for Linux. You'll need pkg-config, libusb, and libqt4 or above through
 a package installer. Macports and Homebrew have been used successfully. Udev doesn't
 exist for macOS so native IOKit is used instead.
 

--- a/TL866_Updater/QT/TL866_Updater.pro
+++ b/TL866_Updater/QT/TL866_Updater.pro
@@ -40,11 +40,13 @@ HEADERS += usb_macos.h \
         notifier_macos.h
 SOURCES += usb_macos.cpp \
         notifier_macos.cpp
-LIBS += -L/opt/local/lib \
-        -lusb-1.0 \
+LIBS += `pkg-config --libs-only-l libusb-1.0` \
         -framework IOKit \
         -framework Carbon
-QMAKE_CXXFLAGS += "-std=c++0x"
+QMAKE_CXX = clang
+QMAKE_CXXFLAGS += "-std=c++0x" \
+        `pkg-config --cflags libusb-1.0`
+QMAKE_LFLAGS += `pkg-config --libs-only-L libusb-1.0`
 INCPATH += /opt/local/include
 }
 

--- a/TL866_Updater/QT/usb_macos.h
+++ b/TL866_Updater/QT/usb_macos.h
@@ -3,7 +3,7 @@
 
 #include <glob.h>
 #include <QList>
-#include <libusb-1.0/libusb.h>
+#include <libusb.h>
 
 class USB
 {


### PR DESCRIPTION
Note that this does introduce pkg-config as a compile-time dependency.  However, it does allow for compilation with Homebrew-installed libraries without additional steps.