### PR TITLE
Fix build against Qt 6.7 version

### DIFF
--- a/TL866_Updater/QT/hexwriter.h
+++ b/TL866_Updater/QT/hexwriter.h
@@ -1,5 +1,6 @@
 #ifndef HEXWRITER_H
 #define HEXWRITER_H
+#include <QString>
 #include <QTextStream>
 
 class HexWriter


### PR DESCRIPTION
Seems like there were some changes in QTextStream class that now warrant QString include as well.

Fixes #55 