### PR TITLE
Remove unused model detection, fix types to match libusb

### DIFF
--- a/wine/setupapi.c
+++ b/wine/setupapi.c
@@ -23,17 +23,13 @@
 #define TL866A_PID 0xe11c
 #define TL866II_VID 0xA466
 #define TL866II_PID 0x0A53
-#define MODEL_A		0x1
-#define MODEL_II	0x2
-#define MODEL_T48	0x3
-#define MODEL_T56	0x4
 
 typedef struct {
   HANDLE InterfaceHandle;
   UCHAR PipeID;
   PUCHAR Buffer;
   ULONG BufferLength;
-  PULONG LengthTransferred;
+  PUINT LengthTransferred;
   LPOVERLAPPED Overlapped;
 } Args;
 
@@ -42,7 +38,6 @@ typedef struct {
 libusb_device_handle *device_handle[4];
 libusb_device **devs;
 int debug = 0;
-int model = 0;
 
 HANDLE h_thread;
 
@@ -189,13 +184,8 @@ int open_devices() {
               LIBUSB_SUCCESS) {
         usb_handle[devices_found] = (HANDLE)devices_found;
         if(device_vid == TL866II_VID){
-            char product[50];
             winusb_handle[devices_found] = (HANDLE)devices_found;
             *devices_count = devices_found + 1;
-            libusb_get_string_descriptor_ascii(device_handle[devices_found], desc.iProduct, product, 50);
-            if (strncmp(product, "XGecu T48", 9) == 0) model = MODEL_T48; else model = MODEL_II;
-        } else {
-            model = MODEL_A;
         }
         devices_found++;
         if (devices_found == 4) return 0;
@@ -233,7 +223,7 @@ void async_transfer(Args *args) {
 // WinUsb_ReadPipe/winUsb_WritePipe LibUsb implementation.
 BOOL __stdcall WinUsb_Transfer(HANDLE InterfaceHandle, UCHAR PipeID,
                                PUCHAR Buffer, ULONG BufferLength,
-                               PULONG LengthTransferred,
+                               PUINT LengthTransferred,
                                LPOVERLAPPED Overlapped) {
   if (InterfaceHandle == INVALID_HANDLE_VALUE) return FALSE;
   if (device_handle[(int)InterfaceHandle] == NULL) return FALSE;


### PR DESCRIPTION
The current build of setupapi.dll does not appear to work on linux. This patch removes what appears to be broken model detection and fixes the types of several parameters to get the code working again.

Tested with an Xgecu T56 on Arch linux.

Fixes issues #51 and #53 